### PR TITLE
Intentional Bug: Order form submit doesn't work

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
## Changes
1. Changed state variable used in menuItemChosen handler to `order_item`.

## Purpose
Order form submit doesn't work.

## Approach
The correct variable `order_item` is used and updated when the `onChange` event is triggered during menu selection.

Closes [#14](https://github.com/Shift3/react-challenge-project/issues/14)