### PR TITLE
Feat: Add "edit" and "delete" order functionality

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -15,12 +15,12 @@ class OrderForm extends Component {
         super(props);
         this.state = {
             order_item: "",
-            quantity: "1"
+            quantity: "1",
         }
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {
@@ -35,7 +35,7 @@ class OrderForm extends Component {
             body: JSON.stringify({
                 order_item: this.state.order_item,
                 quantity: this.state.quantity,
-                ordered_by: this.props.auth.email || 'Unknown!',
+                ordered_by: this.props.auth.email || 'Unknown!'
             }),
             headers: {
                 'Content-Type': 'application/json'

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -4,10 +4,16 @@ import { SERVER_IP } from '../../private';
 import './viewOrders.css';
 
 const DELETE_ORDER_URL = `${SERVER_IP}/api/delete-order`
+const EDIT_ORDER_URL = `${SERVER_IP}/api/edit-order`
 
 class ViewOrders extends Component {
-    state = {
-        orders: []
+    constructor(props){
+        super(props);
+        this.state = {
+            orders: [],
+            isEditing: false,
+            quantity: '',
+        };
     }
 
     componentDidMount() {
@@ -22,11 +28,48 @@ class ViewOrders extends Component {
             });
     }
 
+    editOrder(){
+        this.setState({isEditing: !this.state.isEditing});
+    }
+
+    menuQuantityChosen(event) {
+        console.log(event.target.value)
+        this.setState({quantity: event.target.value})
+    }
+
+    /*
+    Edit order functionality.
+    Issues: When an EDIT button is clicked, every order is toggled to edit.
+            While the drop down menu selection is applied to each other, only
+            the saved item is adjusted. In addition, a refresh will show the true updated quantity
+    I would need to debug the problem with quantity showing only after a refresh.
+     */
+    updateOrder(order){
+        fetch(EDIT_ORDER_URL, {
+            method: 'POST',
+            body: JSON.stringify({
+                id: order._id,
+                order_item: order.order_item,
+                quantity: this.state.quantity,
+                ordered_by: order.ordered_by
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }).then(response => {
+            if(response.ok){
+                console.log('Order Updated')
+            } else {
+                console.log('Unable to update order')
+            }})
+        this.setState({isEditing: false})
+    }
+
     deleteOrder(order_id){
         fetch(DELETE_ORDER_URL, {
             method: 'POST',
             body: JSON.stringify({
-                id: order_id
+                id: order_id,
             }),
             headers: {
                 'Content-Type': 'application/json'
@@ -59,14 +102,31 @@ class ViewOrders extends Component {
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
                                     <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
-                                    <p>Quantity: {order.quantity}</p>
+                                    {this.state.isEditing ? (
+                                        <select value={this.state.quantity} onChange={(event) => this.menuQuantityChosen(event, this.value)}>
+                                            <option value="1">1</option>
+                                            <option value="2">2</option>
+                                            <option value="3">3</option>
+                                            <option value="4">4</option>
+                                            <option value="5">5</option>
+                                            <option value="6">6</option>
+                                        </select>
+                                    ) : (
+                                        <p>Quantity: {order.quantity}</p>
+                                    )
+                                    }
                                  </div>
                                  <div className="col-md-4 view-order-right-col">
-                                     <button className="btn btn-success">Edit</button>
-                                     <button className="btn btn-danger" onClick={() => this.deleteOrder(order._id)}>Delete</button>
+                                     {this.state.isEditing ? (
+                                         <button className="btn btn-success" onClick={(event) => this.updateOrder(order)}>Save Edit</button>
+                                     ) : (
+                                         <button className="btn btn-success" onClick={(event) =>
+                                         this.editOrder()}>Edit</button>
+                                     )}
+                                    <button className="btn btn-danger" onClick={() => this.deleteOrder(order._id)}>Delete</button>
                                  </div>
                             </div>
-                        );
+                       );
                     })}
                 </div>
             </Template>

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -3,6 +3,8 @@ import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
 import './viewOrders.css';
 
+const DELETE_ORDER_URL = `${SERVER_IP}/api/delete-order`
+
 class ViewOrders extends Component {
     state = {
         orders: []
@@ -18,6 +20,29 @@ class ViewOrders extends Component {
                     console.log('Error getting orders');
                 }
             });
+    }
+
+    deleteOrder(order_id){
+        fetch(DELETE_ORDER_URL, {
+            method: 'POST',
+            body: JSON.stringify({
+                id: order_id
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => {
+            if(response.ok){
+                console.log('SUCCESS')
+            } else {
+                console.log('Not Successful')
+        }})
+        .then(
+             this.setState(prevState => ({
+                orders: prevState.orders.filter(order => order._id !== order_id)
+        })))
+        .catch(error => console.log(error))
     }
 
     render() {
@@ -38,7 +63,7 @@ class ViewOrders extends Component {
                                  </div>
                                  <div className="col-md-4 view-order-right-col">
                                      <button className="btn btn-success">Edit</button>
-                                     <button className="btn btn-danger">Delete</button>
+                                     <button className="btn btn-danger" onClick={() => this.deleteOrder(order._id)}>Delete</button>
                                  </div>
                             </div>
                         );


### PR DESCRIPTION
## Changes
1. Added a delete order functionality to the existing delete button
2. Added an edit order functionality to the existing edit button
3. Added a drop down menu to edit quantity of an order and  a save button

## Purpose
Edit and Delete button originally did nothing.

## Approach
Looked into how `submitOrder` in `OrderForm` was coded and applied that knowledge into creating functionality to both Edit and Delete. In addition, I reused code from `OrderForm` to add a drop down menu for editing the quantity of an item.

Closes [ #15](https://github.com/Shift3/react-challenge-project/issues/15)