### PR TITLE
Feat: create guard route for viewOrders and orderForm

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Main, Login, OrderForm, ViewOrders } from '../components';
+import RouteGuard from './routeGuard/routeGuard';
 
 const AppRouter = (props) => {
   return (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+      <RouteGuard path="/order" exact component={OrderForm} />
+      <RouteGuard path="/view-orders" exact component={ViewOrders} />
     </Router>
   );
 }

--- a/application/src/router/routeGuard/routeGuard.js
+++ b/application/src/router/routeGuard/routeGuard.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { connect } from 'react-redux';
+import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
+
+const mapStateToProps = (state) => ({
+    auth: state.auth
+})
+
+const RouteGuard = ({component: Component, auth, ...rest }) => {
+    return (
+        <Route { ...rest }>
+            {auth.token ? <Component /> : <Redirect to={"/"}/>}
+        </Route>
+    )
+}
+
+export default connect(mapStateToProps, null)(RouteGuard);


### PR DESCRIPTION
## Changes
1. Added the `routeGuard.js` file for the guarded routes.
2. Import guard routes to `orderForm` and `viewOrders`

## Purpose
Users that were not logged in were able to access `orderForm` and `viewOrders` and place orders.

## Approach
The added route guards now require users to login before accessing the forms.

## Learning
Huge learning experience. This one personally took the longest to get it right. I believe there is a bug I created when trying to log in for the first time. Occasionally, it redirects me to the main page when attempting to login. I will revisit this afterwards. Regardless, the following links lead to a solution:

[Redirects (Auth)](https://reactrouter.com/web/example/auth-workflow)
[How to implement authenticated routes in React Router 4?](https://stackoverflow.com/questions/43164554/how-to-implement-authenticated-routes-in-react-router-4)
[Protected routes and authentication with React Router v5](https://ui.dev/react-router-v5-protected-routes-authentication/)
[Protected Routes in ReactJS - React Router Dom](https://www.youtube.com/watch?v=qnH5KNtRYEI)

Closes [#21](https://github.com/Shift3/react-challenge-project/issues/21)