### PR TITLE
Fix: fix order time to correct format

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -18,6 +18,13 @@ class ViewOrders extends Component {
                     console.log('Error getting orders');
                 }
             });
+    }   
+
+    formatTime(hours, minutes, seconds){
+        const formatHours = hours.toString().padStart(2,0);
+        const formatMinutes = minutes.toString().padStart(2,0);
+        const formatSeconds = seconds.toString().padStart(2,0);
+        return [formatHours, formatMinutes, formatSeconds].join(':')
     }
 
     render() {
@@ -33,7 +40,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {this.formatTime(createdDate.getHours(), createdDate.getMinutes(), createdDate.getSeconds())}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
1. Added a function to padding to hour, minutes and time for proper formatting.
2. Removed old line of code that attempted formatting.

## Purpose
Order time was not displayed in the correct format: `hh:mm:ss`

## Approach
Padding has been applied to the format and a function was created to handle it.

Closes [#30](https://github.com/Shift3/react-challenge-project/issues/30)